### PR TITLE
Check message identifier is idempotent

### DIFF
--- a/src/TbdDevelop.Kafka.Outbox/InMemoryMessageOutbox.cs
+++ b/src/TbdDevelop.Kafka.Outbox/InMemoryMessageOutbox.cs
@@ -26,6 +26,7 @@ public class InMemoryMessageOutbox : IMessageOutbox
                 var storedMessage = GetMessageForKey(message.Identifier);
                 //Console.WriteLine($"Operation with key '{message.Identifier}' and message '{storedMessage}' is already processed. Skipping.");
                 _logger.LogInformation($"Operation with key '{message.Identifier}' and message '{storedMessage}' is already processed. Skipping.");
+                return;
             }
 
             _outbox.TryAdd(message.Identifier, message);

--- a/src/TbdDevelop.Kafka.Outbox/InMemoryMessageOutbox.cs
+++ b/src/TbdDevelop.Kafka.Outbox/InMemoryMessageOutbox.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
 using TbdDevelop.Kafka.Abstractions;
 using TbdDevelop.Kafka.Outbox.Contracts;
 
@@ -6,6 +7,11 @@ namespace TbdDevelop.Kafka.Outbox;
 
 public class InMemoryMessageOutbox : IMessageOutbox
 {
+    private readonly ILogger<InMemoryMessageOutbox> _logger;
+    public InMemoryMessageOutbox(ILogger<InMemoryMessageOutbox> logger)
+    {
+        _logger = logger;
+    }
     private readonly ConcurrentDictionary<Guid, IOutboxMessage> _outbox = new();
 
     public async Task PostAsync<TEvent>(TEvent @event, CancellationToken cancellationToken = default)
@@ -15,8 +21,26 @@ public class InMemoryMessageOutbox : IMessageOutbox
         {
             var message = new OutboxMessage<TEvent>(@event);
 
+            if (IsIdempotent(message.Identifier))
+            {
+                var storedMessage = GetMessageForKey(message.Identifier);
+                //Console.WriteLine($"Operation with key '{message.Identifier}' and message '{storedMessage}' is already processed. Skipping.");
+                _logger.LogInformation($"Operation with key '{message.Identifier}' and message '{storedMessage}' is already processed. Skipping.");
+            }
+
             _outbox.TryAdd(message.Identifier, message);
         }, cancellationToken);
+    }
+
+    private bool IsIdempotent(Guid key)
+    {
+        return _outbox.ContainsKey(key);
+    }
+
+    private IOutboxMessage GetMessageForKey(Guid key)
+    {
+        _outbox.TryGetValue(key, out var storedMessage);
+        return storedMessage; // possible null reference return
     }
 
     public Task<IOutboxMessage?> RetrieveNextMessage(CancellationToken cancellationToken = default)
@@ -24,8 +48,8 @@ public class InMemoryMessageOutbox : IMessageOutbox
         return Task.Run(() =>
         {
             var nextMessage = (from message in _outbox.Values
-                orderby message.AddedOn
-                select message).FirstOrDefault();
+                               orderby message.AddedOn
+                               select message).FirstOrDefault();
 
             return nextMessage;
         }, cancellationToken);

--- a/src/TbdDevelop.Kafka.Outbox/InMemoryMessageOutbox.cs
+++ b/src/TbdDevelop.Kafka.Outbox/InMemoryMessageOutbox.cs
@@ -23,9 +23,7 @@ public class InMemoryMessageOutbox : IMessageOutbox
 
             if (IsIdempotent(message.Identifier))
             {
-                var storedMessage = GetMessageForKey(message.Identifier);
-                //Console.WriteLine($"Operation with key '{message.Identifier}' and message '{storedMessage}' is already processed. Skipping.");
-                _logger.LogInformation($"Operation with key '{message.Identifier}' and message '{storedMessage}' is already processed. Skipping.");
+                _logger.LogInformation($"Operation with key '{message.Identifier}' is already processed. Skipping.");
                 return;
             }
 
@@ -36,12 +34,6 @@ public class InMemoryMessageOutbox : IMessageOutbox
     private bool IsIdempotent(Guid key)
     {
         return _outbox.ContainsKey(key);
-    }
-
-    private IOutboxMessage GetMessageForKey(Guid key)
-    {
-        _outbox.TryGetValue(key, out var storedMessage);
-        return storedMessage; // possible null reference return
     }
 
     public Task<IOutboxMessage?> RetrieveNextMessage(CancellationToken cancellationToken = default)


### PR DESCRIPTION
Since concurrentdictionary was used, the message was checked before being added to the outbox to ensure that it was unique.